### PR TITLE
trim non-breaking spaces

### DIFF
--- a/src/main/scala/netkeiba-scraper/Main.scala
+++ b/src/main/scala/netkeiba-scraper/Main.scala
@@ -215,7 +215,7 @@ object RowExtractor {
         Array(round.split(" ").head, fieldScore) ++ 
         { val di = dateInfo.split(" ")
           di.take(2) :+ di.drop(2).mkString(" ") }).
-        map(_.filter(_ != '?').trim).
+        map(_.filter(_ != '?').replaceAll("(^\\h*)|(\\h*$)","")).
         mkString(",").split(",")
 
       val raceInfo = str2raceInfo(raceInfoStr)


### PR DESCRIPTION
以下のようなエラーを解決します。

```
$ sbt "run extract"
...
[error] (run-main-0) java.lang.NumberFormatException: For input string: "1500 "
java.lang.NumberFormatException: For input string: "1500 "
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:580)
    at java.lang.Integer.parseInt(Integer.java:615)
    at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:229)
    at scala.collection.immutable.StringOps.toInt(StringOps.scala:31)
    at RowExtractor$.str2raceInfo(Main.scala:70)
    at RowExtractor$.extract(Main.scala:221)
    at Main$$anonfun$77.apply(Main.scala:1983)
    at Main$$anonfun$77.apply(Main.scala:1979)
    at scalikejdbc.DBConnection$$anonfun$_localTx$1$1.apply(DBConnection.scala:252)
    at scala.util.control.Exception$Catch.apply(Exception.scala:102)
    at scalikejdbc.DBConnection$class._localTx$1(DBConnection.scala:250)
    at scalikejdbc.DBConnection$class.localTx(DBConnection.scala:258)
    at scalikejdbc.DB.localTx(DB.scala:75)
    at scalikejdbc.DB$$anonfun$localTx$1.apply(DB.scala:257)
    at scalikejdbc.DB$$anonfun$localTx$1.apply(DB.scala:256)
    at scalikejdbc.LoanPattern$class.using(LoanPattern.scala:33)
    at scalikejdbc.DB$.using(DB.scala:150)
    at scalikejdbc.DB$.localTx(DB.scala:256)
    at Main$.main(Main.scala:1979)
    at Main.main(Main.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:497)
[trace] Stack trace suppressed: run last compile:run for the full output.
java.lang.RuntimeException: Nonzero exit code: 1
    at scala.sys.package$.error(package.scala:27)
[trace] Stack trace suppressed: run last compile:run for the full output.
[error] (compile:run) Nonzero exit code: 1
...
```

これは、コース距離のあとに通常のスペースではなく、[ノーブレークスペース](https://ja.wikipedia.org/wiki/%E3%83%8E%E3%83%BC%E3%83%96%E3%83%AC%E3%83%BC%E3%82%AF%E3%82%B9%E3%83%9A%E3%83%BC%E3%82%B9)が入っていることに起因します。

当方の環境は以下の通りです。

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.3 LTS"

$ sqlite3 --version
3.8.2 2013-12-06 14:53:30 27392118af4c38c5203a04b8013e1afdb1cebd0d

$ java -version
java version "1.8.0_66"
Java(TM) SE Runtime Environment (build 1.8.0_66-b17)
Java HotSpot(TM) 64-Bit Server VM (build 25.66-b17, mixed mode)

$ scala -version
Scala code runner version 2.11.7 -- Copyright 2002-2013, LAMP/EPFL
```
